### PR TITLE
fix model default comment

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 import requests
 import os
 
-MODEL_NAME = os.getenv("MODEL_NAME", "mistral")  # Default es 'phi' por si no está en .env
+MODEL_NAME = os.getenv("MODEL_NAME", "mistral")  # Default es 'mistral' por si no está en .env
 
 app = FastAPI(
     title="AIF369 WhatsApp Bot",


### PR DESCRIPTION
## Summary
- correct comment for `MODEL_NAME` default to 'mistral'

## Testing
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68979529c72883309a371e33d3ab5ec2