### PR TITLE
Handle missing contexto file gracefully

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 import requests
 import os
+import logging
 
 MODEL_NAME = os.getenv("MODEL_NAME", "mistral")  # Default es 'phi' por si no está en .env
 
@@ -14,9 +15,15 @@ app = FastAPI(
 class ChatPrompt(BaseModel):
     prompt: str
 
+logger = logging.getLogger(__name__)
+
 # Leer contexto desde archivo
-with open("contexto.txt", "r", encoding="utf-8") as file:
-    CONTEXTO = file.read()
+try:
+    with open("contexto.txt", "r", encoding="utf-8") as file:
+        CONTEXTO = file.read()
+except FileNotFoundError:
+    CONTEXTO = ""
+    logger.warning("contexto.txt not found; continuing without context")
 
 @app.get("/")
 async def home():


### PR DESCRIPTION
## Summary
- avoid startup failure when contexto.txt missing by wrapping read in try/except
- log a warning and default to an empty context string

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68979518aa148330a9e7acef93b5ad9b