### PR TITLE
Add CI/CD workflow for dev, QA, prod

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,0 +1,33 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [development, qa, production]
+    env:
+      ENVIRONMENT: ${{ matrix.environment }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -q
+      - name: Build Docker image
+        run: docker build -t aif369:${{ matrix.environment }} .
+      - name: Deploy
+        if: github.ref == 'refs/heads/main'
+        run: echo "Deploying to $ENVIRONMENT environment"


### PR DESCRIPTION
## Summary
- add GitHub Actions pipeline with development, QA, and production stages
- install dependencies, run tests, build Docker image and placeholder deploy for each environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689911e7071883308ebdb09d99f2c73c